### PR TITLE
Update docs with jq requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Use natural language without copying between CoPilot or ChatGPT
 wget -qO- https://autocomplete.sh/install.sh | bash
 ```
 
+Autocomplete.sh requires `jq` for JSON parsing. Install it with your package manager if it's not already present:
+
+- **Ubuntu/Debian:** `sudo apt-get install jq`
+- **CentOS/RHEL:** `sudo yum install jq`
+- **macOS (Homebrew):** `brew install jq`
+
 ## Features
 
 - **Context-Aware**: Considers terminal state, recent commands, and `--help` information
@@ -95,6 +101,12 @@ git clone git@github.com:closedloop-technologies/autocomplete-sh.git
 ln -s $PWD/autocomplete.sh $HOME/.local/bin/autocomplete
 . autocomplete.sh install
 ```
+
+This script requires `jq`:
+
+- **Ubuntu/Debian:** `sudo apt-get install jq`
+- **CentOS/RHEL:** `sudo yum install jq`
+- **macOS (Homebrew):** `brew install jq`
 
 We can also install the development version from the local file:
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -10,11 +10,17 @@
 
 2. **Install the Script**  
 
-   ```bash
-   autocomplete install
-   ```  
+```bash
+autocomplete install
+```
 
-   *This adds the necessary lines to your ~/.bashrc and sets up the environment.*
+Autocomplete.sh relies on `jq`:
+
+- **Ubuntu/Debian:** `sudo apt-get install jq`
+- **CentOS/RHEL:** `sudo yum install jq`
+- **macOS (Homebrew):** `brew install jq`
+
+*This adds the necessary lines to your ~/.bashrc and sets up the environment.*
 
 3. **Reload Your Shell**  
 


### PR DESCRIPTION
## Summary
- document jq dependency in installation instructions
- update usage guide with jq install hints

## Testing
- `./run_tests.sh` *(fails: `bats` not found)*