### PR TITLE
Add dynamic model retrieval note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# Agent Guidelines for Autocomplete.sh
+
+These instructions apply to the entire repository.
+
+## Testing
+- Run `./run_tests.sh` and ensure all tests pass before committing.
+- The tests require `bats`. Install with `sudo apt install bats` if not available.
+- Ensure the environment variable `OPENAI_API_KEY` is set when running tests.
+
+## Style
+- Use POSIX-compatible shell scripting in `.sh` and `.zsh` files.
+- Run `pre-commit run --files <changed files>` to lint scripts with `shellcheck`.
+- Avoid committing secrets or API keys.
+
+## Documentation
+- Update README.md or USAGE.md when adding new commands or configuration options.
+

--- a/next.md
+++ b/next.md
@@ -1,0 +1,12 @@
+# Next Steps for Multi-Model Support via Litellm
+
+The repository currently supports OpenAI, Groq, Anthropic, and Ollama models. To enable additional models through the litellm endpoint at `https://llm.co.sig9.dev`, consider the following changes:
+
+1. **Add a new provider** `litellm` in both `autocomplete.sh` and `autocomplete.zsh`.
+2. **Fetch models dynamically** by querying the litellm endpoint (e.g. `GET $ACSH_ENDPOINT/models`) at runtime instead of hard-coding the list.
+3. **Introduce a configuration option** for `LITELLM_API_KEY` and allow setting a custom endpoint (`ACSH_ENDPOINT`).
+4. **Update the payload builder** so the request format matches what the litellm service expects. The provider should behave similarly to the OpenAI API.
+5. **Update the `model` command** to accept litellm models and switch the active provider accordingly.
+6. **Add tests** in `tests/test_autocomplete.bats` to exercise the new provider and ensure completions work when the environment variables are set.
+7. **Document usage** in README.md and USAGE.md, including example commands for configuring the API key and endpoint.
+


### PR DESCRIPTION
## Summary
- document dynamic model retrieval from the Litellm endpoint

## Testing
- `pre-commit run --files next.md` *(fails: `pre-commit: command not found`)*
- `./run_tests.sh` *(fails: `bats: command not found`)*